### PR TITLE
Add Noctua GO-CAM specialist agent with noctua-py integration

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -49,6 +49,9 @@ redis>=5.0
 # CLI support
 click
 
+# Noctua GO-CAM integration
+noctua-py
+
 # Testing
 pytest
 pytest-asyncio

--- a/backend/src/api/chat.py
+++ b/backend/src/api/chat.py
@@ -547,6 +547,7 @@ async def chat_stream_endpoint(chat_message: ChatMessage, user: Dict[str, Any] =
     """Stream a chat response using Server-Sent Events."""
     session_id = chat_message.session_id or str(uuid.uuid4())
     user_id = user.get("sub")
+    barista_token = user.get("barista_token")
 
     if not user_id:
         raise HTTPException(status_code=401, detail="User identifier not found in token")
@@ -634,6 +635,7 @@ async def chat_stream_endpoint(chat_message: ChatMessage, user: Dict[str, Any] =
                 document_name=document_name,
                 conversation_history=conversation_history,
                 active_groups=active_groups,
+                barista_token=barista_token,
             ):
                 # Check for cancellation (local event OR Redis signal)
                 if cancel_event.is_set() or await check_cancel_signal(current_session_id):

--- a/backend/src/lib/agent_studio/catalog_service.py
+++ b/backend/src/lib/agent_studio/catalog_service.py
@@ -962,6 +962,7 @@ def _binding_context_payload(
             "document_id": execution_context.document_id,
             "user_id": execution_context.user_id,
             "database_url": execution_context.database_url,
+            "barista_token": execution_context.barista_token,
         }
 
     required_context = set(binding.required_context)
@@ -1276,6 +1277,7 @@ class ToolExecutionContext:
     document_id: Optional[str] = None
     user_id: Optional[str] = None
     database_url: Optional[str] = None
+    barista_token: Optional[str] = None
     tool_tracker: Optional[Any] = None
 
 def _canonicalize_tool_id(tool_id: str) -> str:
@@ -1756,10 +1758,14 @@ def _build_tool_execution_context(
         env_database_url = os.getenv("CURATION_DB_URL", "").strip()
         database_url = env_database_url or None
 
+    raw_barista_token = kwargs.get("barista_token")
+    barista_token = str(raw_barista_token) if raw_barista_token not in (None, "") else None
+
     return ToolExecutionContext(
         document_id=document_id,
         user_id=user_id,
         database_url=database_url,
+        barista_token=barista_token,
         tool_tracker=tool_tracker,
     )
 

--- a/backend/src/lib/openai_agents/agents/supervisor_agent.py
+++ b/backend/src/lib/openai_agents/agents/supervisor_agent.py
@@ -332,6 +332,7 @@ def _create_dynamic_specialist_tools(
     abstract: Optional[str] = None,
     active_groups: Optional[List[str]] = None,
     tool_specs: Optional[List[Dict[str, Any]]] = None,
+    barista_token: Optional[str] = None,
 ) -> List[Callable]:
     """
     Dynamically create specialist tools based on unified agent records.
@@ -381,6 +382,10 @@ def _create_dynamic_specialist_tools(
         if group_rules_enabled and active_groups:
             agent_kwargs["active_groups"] = active_groups
 
+        # Pass Barista token for Noctua-integrated tools
+        if barista_token:
+            agent_kwargs["barista_token"] = barista_token
+
         try:
             # Create the agent instance from unified spec.
             agent = get_agent_by_id(agent_key, **agent_kwargs)
@@ -420,6 +425,7 @@ def create_supervisor_agent(
     abstract: Optional[str] = None,
     enable_guardrails: bool = False,  # Enable input guardrails (PII detection, topic check)
     active_groups: Optional[List[str]] = None,  # Group-specific rules to inject (e.g., ["MGI", "FB"])
+    barista_token: Optional[str] = None,  # Barista session token for Noctua integration
 ) -> Agent:
     """
     Create a Supervisor agent with dynamically discovered specialist tools.
@@ -518,6 +524,7 @@ def create_supervisor_agent(
         abstract=abstract,
         active_groups=active_groups,
         tool_specs=tool_specs,
+        barista_token=barista_token,
     )
 
     routing_duration_ms = (time.monotonic() - route_start) * 1000

--- a/backend/src/lib/openai_agents/runner.py
+++ b/backend/src/lib/openai_agents/runner.py
@@ -936,6 +936,7 @@ async def run_agent_streamed(
     active_groups: Optional[List[str]] = None,
     agent: Optional[Agent] = None,
     doc_context: Optional["DocumentContext"] = None,
+    barista_token: Optional[str] = None,
 ) -> AsyncGenerator[Dict[str, Any], None]:
     """
     Run an agent with streaming output.
@@ -1021,6 +1022,7 @@ async def run_agent_streamed(
             hierarchy=hierarchy,
             abstract=abstract,
             active_groups=active_groups,
+            barista_token=barista_token,
         )
         agent_name = agent.name
     else:

--- a/packages/alliance/agents/noctua/agent.yaml
+++ b/packages/alliance/agents/noctua/agent.yaml
@@ -1,0 +1,66 @@
+# =============================================================================
+# AGENT DEFINITION: noctua
+# =============================================================================
+# Creates and edits GO-CAM (Gene Ontology Causal Activity Models) via Noctua.
+# Tool name generated at runtime: ask_noctua_specialist
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# BASIC INFORMATION
+# -----------------------------------------------------------------------------
+agent_id: noctua
+
+name: "Noctua GO-CAM Agent"
+
+description: >
+  Creates, queries, and edits Gene Ontology Causal Activity Models (GO-CAMs)
+  via the Noctua/Barista API. Supports listing models, adding molecular
+  activities, creating causal relationships with evidence, and exporting models.
+
+category: "Curation"
+subcategory: "GO-CAM Modeling"
+
+# -----------------------------------------------------------------------------
+# SUPERVISOR ROUTING
+# -----------------------------------------------------------------------------
+supervisor_routing:
+  enabled: true
+  description: >
+    Use for creating or editing GO-CAM models, adding molecular activities
+    or causal relationships to models, querying existing GO-CAM models,
+    or any task involving Noctua or causal activity modeling.
+  batchable: false
+
+# -----------------------------------------------------------------------------
+# TOOLS
+# -----------------------------------------------------------------------------
+tools:
+  - noctua_gocam
+
+# -----------------------------------------------------------------------------
+# MODEL CONFIGURATION
+# -----------------------------------------------------------------------------
+model_config:
+  model: "${AGENT_NOCTUA_MODEL:-gpt-4o}"
+  temperature: 0.1
+  reasoning: "low"
+
+# -----------------------------------------------------------------------------
+# EXECUTION REQUIREMENTS
+# -----------------------------------------------------------------------------
+requires_document: false
+required_params: []
+
+batch_capabilities: []
+
+# -----------------------------------------------------------------------------
+# FRONTEND DISPLAY
+# -----------------------------------------------------------------------------
+frontend:
+  icon: "🦉"
+  show_in_palette: true
+
+# -----------------------------------------------------------------------------
+# GROUP RULES
+# -----------------------------------------------------------------------------
+group_rules_enabled: false

--- a/packages/alliance/agents/noctua/prompt.yaml
+++ b/packages/alliance/agents/noctua/prompt.yaml
@@ -1,0 +1,79 @@
+# =============================================================================
+# AGENT PROMPT: noctua
+# =============================================================================
+# System prompt for the Noctua GO-CAM specialist agent.
+# =============================================================================
+
+agent_id: noctua
+content: |
+  <role>
+  You are a GO-CAM (Gene Ontology Causal Activity Model) specialist.
+
+  You create and edit GO-CAM models using the Noctua platform via the noctua_gocam tool.
+  GO-CAM models represent biological pathways as networks of molecular activities
+  connected by causal relationships, grounded in evidence from the literature.
+  </role>
+
+  <gocam_reference>
+  ## HOW GO-CAM MODELS WORK
+
+  ### Structure
+  A GO-CAM model consists of:
+  - **Individuals**: Instances of molecular activities (GO terms), typically
+    Molecular Function terms like "kinase activity" (GO:0016301)
+  - **Facts/Edges**: Causal relationships between activities using Relation
+    Ontology (RO) predicates
+  - **Evidence**: ECO evidence codes and literature references (PMIDs)
+    supporting each relationship
+
+  ### Common Relation Ontology Predicates
+  - RO:0002413 - "directly provides input for" (causal chain)
+  - RO:0002629 - "directly positively regulates"
+  - RO:0002630 - "directly negatively regulates"
+  - RO:0002331 - "involved in" (activity → process)
+  - RO:0002333 - "enabled by" (activity → gene product)
+  - BFO:0000066 - "occurs in" (activity → cellular component)
+
+  ### Common Evidence Codes (ECO)
+  - ECO:0000314 - direct assay evidence used in manual assertion
+  - ECO:0000315 - mutant phenotype evidence used in manual assertion
+  - ECO:0000316 - genetic interaction evidence used in manual assertion
+  - ECO:0000353 - physical interaction evidence used in manual assertion
+  - ECO:0007669 - computational evidence used in automatic assertion
+
+  ### Variable Tracking
+  When adding individuals, use the assign_var parameter to give them
+  readable names (e.g., "ras_activity", "raf_kinase"). These can be used
+  as subject/object in subsequent add_fact calls instead of raw IDs.
+  </gocam_reference>
+
+  <critical_instructions>
+  ## CRITICAL INSTRUCTIONS
+  - ALWAYS use the noctua_gocam tool for ALL operations — never guess model state
+  - When creating a pathway, work step by step: create model → add individuals → add facts
+  - Use assign_var to name individuals for readability in subsequent operations
+  - Always cite evidence (PMIDs) when adding causal relationships
+  - Use list_models or get_model to inspect state before making edits
+  - If an operation fails, report the error clearly — do not retry silently
+  - Gene products should be referenced using UniProt IDs (UniProtKB:XXXXX) or
+    other standard identifiers
+  </critical_instructions>
+
+  <workflow_guidance>
+  ## TYPICAL WORKFLOW
+
+  1. **Create a model**: action=create_model with a descriptive title
+  2. **Add molecular activities**: action=add_individual with GO MF terms,
+     using assign_var for each (e.g., "kinase", "receptor")
+  3. **Connect activities**: action=add_fact or add_evidence to create
+     causal links between individuals
+  4. **Review**: action=get_model to inspect the current state
+  5. **Export**: action=export_model to get the model in a desired format
+
+  ## EXAMPLE: Simple Signaling Pathway
+  1. create_model(title="RAS-RAF signaling")
+  2. add_individual(model_id=..., class_curie="GO:0003924", assign_var="ras")  # GTPase activity
+  3. add_individual(model_id=..., class_curie="GO:0004674", assign_var="raf")  # protein kinase activity
+  4. add_evidence(model_id=..., subject="ras", object_="raf",
+     predicate="RO:0002629", eco_id="ECO:0000314", sources="PMID:12345678")
+  </workflow_guidance>

--- a/packages/alliance/python/src/agr_ai_curation_alliance/tools/noctua.py
+++ b/packages/alliance/python/src/agr_ai_curation_alliance/tools/noctua.py
@@ -1,0 +1,212 @@
+"""Noctua GO-CAM tool factories for the AGR Alliance package.
+
+Wraps noctua-py's BaristaClient to expose GO-CAM model operations as
+tools that the AI agent system can invoke. Tools require a barista_token
+in their execution context, obtained via the Barista token exchange at
+login time.
+
+Vibe coded by Claude (Opus 4.6) with SJC, 2026-03-21.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from agents import function_tool
+
+logger = logging.getLogger(__name__)
+
+
+def _require_context_value(context: dict[str, Any], key: str) -> str:
+    value = context.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Missing required context value '{key}'")
+    return value
+
+
+def _summarize_response(resp: Any) -> str:
+    """Convert a BaristaResponse to a concise string for the agent."""
+    if not resp.ok:
+        return f"Error: {resp.error or 'unknown error'}"
+    parts = []
+    if resp.model_id:
+        parts.append(f"model_id: {resp.model_id}")
+    if resp.individuals:
+        parts.append(f"{len(resp.individuals)} individual(s)")
+    if resp.facts:
+        parts.append(f"{len(resp.facts)} fact(s)")
+    if resp.model_vars:
+        parts.append(f"variables: {json.dumps(resp.model_vars)}")
+    return "; ".join(parts) if parts else "OK"
+
+
+def _model_summary(resp: Any) -> str:
+    """Build a structured summary of a full model response."""
+    if not resp.ok:
+        return f"Error: {resp.error or 'unknown error'}"
+    data = resp.data
+    if not data:
+        return f"Model {resp.model_id}: no data returned"
+
+    parts = [f"Model: {resp.model_id}"]
+    if data.annotations:
+        for ann in data.annotations:
+            if ann.key == "title":
+                parts.append(f"Title: {ann.value}")
+    if data.individuals:
+        parts.append(f"\nIndividuals ({len(data.individuals)}):")
+        for ind in data.individuals[:20]:
+            label = ""
+            if ind.root_type and ind.root_type.label:
+                label = ind.root_type.label
+            parts.append(f"  - {ind.id}: {label}")
+    if data.facts:
+        parts.append(f"\nFacts ({len(data.facts)}):")
+        for fact in data.facts[:20]:
+            pred = fact.property_label or fact.property
+            parts.append(f"  - {fact.subject} --[{pred}]--> {fact.object}")
+    return "\n".join(parts)
+
+
+def create_noctua_tool(context: dict[str, Any]):
+    """Create the noctua GO-CAM tool with the user's Barista token."""
+    barista_token = _require_context_value(context, "barista_token")
+
+    # Lazy import so noctua-py is only required when the tool is used
+    from noctua.barista import BaristaClient
+
+    import os
+    barista_base = os.getenv(
+        "BARISTA_BASE_URL", "http://barista-dev.berkeleybop.org"
+    )
+    barista_namespace = os.getenv("BARISTA_NAMESPACE", "minerva_public_dev")
+
+    client = BaristaClient(
+        token=barista_token,
+        base_url=barista_base,
+        namespace=barista_namespace,
+        timeout=30.0,
+    )
+
+    @function_tool
+    def noctua_gocam(
+        action: str,
+        model_id: str = "",
+        title: str = "",
+        class_curie: str = "",
+        assign_var: str = "",
+        subject: str = "",
+        object_: str = "",
+        predicate: str = "",
+        eco_id: str = "",
+        sources: str = "",
+        individual_id: str = "",
+        format: str = "markdown",
+        limit: int = 10,
+    ) -> str:
+        """Query and edit Gene Ontology Causal Activity Models (GO-CAMs) via Noctua.
+
+        Actions:
+          list_models     - List available GO-CAM models (optional: title, limit)
+          get_model       - Get full model details (required: model_id)
+          create_model    - Create a new model (optional: title)
+          add_individual  - Add a molecular entity to a model
+                           (required: model_id, class_curie; optional: assign_var)
+          add_fact        - Add a relationship between two entities
+                           (required: model_id, subject, object_, predicate)
+          add_evidence    - Add a fact with evidence
+                           (required: model_id, subject, object_, predicate,
+                            eco_id, sources as comma-separated PMIDs)
+          remove_fact     - Remove a relationship
+                           (required: model_id, subject, object_, predicate)
+          export_model    - Export model in a format (required: model_id;
+                           optional: format = owl|ttl|json-ld|gaf|markdown)
+
+        GO-CAM models represent biological pathways as causal activity models.
+        Use GO terms (GO:NNNNNNN) for molecular functions/processes,
+        relation ontology terms (RO:NNNNNNN) for predicates,
+        and ECO terms (ECO:NNNNNNN) for evidence codes.
+        """
+        try:
+            if action == "list_models":
+                result = client.list_models(
+                    limit=limit,
+                    title=title or None,
+                )
+                models = result.get("models", [])
+                if not models:
+                    return "No models found."
+                lines = [f"Found {len(models)} model(s):"]
+                for m in models[:limit]:
+                    mid = m.get("id", "?")
+                    mtitle = m.get("title", "(untitled)")
+                    lines.append(f"  - {mid}: {mtitle}")
+                return "\n".join(lines)
+
+            elif action == "get_model":
+                if not model_id:
+                    return "Error: model_id is required for get_model"
+                resp = client.get_model(model_id)
+                return _model_summary(resp)
+
+            elif action == "create_model":
+                resp = client.create_model(title=title or None)
+                return f"Created model: {_summarize_response(resp)}"
+
+            elif action == "add_individual":
+                if not model_id or not class_curie:
+                    return "Error: model_id and class_curie are required"
+                resp = client.add_individual(
+                    model_id,
+                    class_curie,
+                    assign_var=assign_var or "x1",
+                )
+                return f"Added individual: {_summarize_response(resp)}"
+
+            elif action == "add_fact":
+                if not all([model_id, subject, object_, predicate]):
+                    return "Error: model_id, subject, object_, and predicate are required"
+                resp = client.add_fact(model_id, subject, object_, predicate)
+                return f"Added fact: {_summarize_response(resp)}"
+
+            elif action == "add_evidence":
+                if not all([model_id, subject, object_, predicate, eco_id, sources]):
+                    return "Error: model_id, subject, object_, predicate, eco_id, and sources are required"
+                source_list = [s.strip() for s in sources.split(",") if s.strip()]
+                resp = client.add_fact_with_evidence(
+                    model_id, subject, object_, predicate,
+                    eco_id=eco_id, sources=source_list,
+                )
+                return f"Added fact with evidence: {_summarize_response(resp)}"
+
+            elif action == "remove_fact":
+                if not all([model_id, subject, object_, predicate]):
+                    return "Error: model_id, subject, object_, and predicate are required"
+                resp = client.remove_fact(model_id, subject, object_, predicate)
+                return f"Removed fact: {_summarize_response(resp)}"
+
+            elif action == "export_model":
+                if not model_id:
+                    return "Error: model_id is required for export_model"
+                resp = client.export_model(model_id, format=format or "markdown")
+                if resp.ok:
+                    return str(resp.raw.get("data", resp.raw))
+                return f"Export failed: {resp.error}"
+
+            else:
+                return (
+                    f"Unknown action '{action}'. Available actions: "
+                    "list_models, get_model, create_model, add_individual, "
+                    "add_fact, add_evidence, remove_fact, export_model"
+                )
+
+        except Exception as exc:
+            logger.exception("Noctua tool error (action=%s)", action)
+            return f"Error: {exc}"
+
+    return noctua_gocam
+
+
+__all__ = ["create_noctua_tool"]

--- a/packages/alliance/tools/bindings.yaml
+++ b/packages/alliance/tools/bindings.yaml
@@ -62,6 +62,13 @@ tools:
     required_context: []
     description: Query the Alliance API on alliancegenome.org
     source_file: python/src/agr_ai_curation_alliance/tools/rest.py
+  - tool_id: noctua_gocam
+    binding_kind: context_factory
+    callable_factory: agr_ai_curation_alliance.tools.noctua:create_noctua_tool
+    required_context:
+      - barista_token
+    description: Query and edit GO-CAM models via Noctua/Barista
+    source_file: python/src/agr_ai_curation_alliance/tools/noctua.py
   - tool_id: save_csv_file
     binding_kind: static
     callable: agr_ai_curation_alliance.tools.file_output:save_csv_file


### PR DESCRIPTION
## Summary

- Threads `barista_token` from JWT through chat → runner → supervisor → tool context
- New `noctua_gocam` context_factory tool wrapping noctua-py BaristaClient
- New Noctua specialist agent with GO-CAM modeling system prompt
- Actions: list_models, get_model, create_model, add_individual, add_fact, add_evidence, remove_fact, export_model

## Env vars

```
BARISTA_BASE_URL=http://barista-dev.berkeleybop.org
BARISTA_NAMESPACE=minerva_public_dev
```

Refs alliance-genome/agr_ai_curation#119
Depends on PR #1 (Barista token exchange)

## Test plan

- [ ] Agent appears in supervisor routing when barista_token is present
- [ ] list_models returns models from barista-dev
- [ ] create_model creates a model on barista-dev
- [ ] add_individual + add_fact creates entities and relationships
- [ ] Tool gracefully errors when barista_token is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)